### PR TITLE
fix(showcase): Correct an invalid icon reference to prevent build fai…

### DIFF
--- a/src/components/Showcase.tsx
+++ b/src/components/Showcase.tsx
@@ -4,7 +4,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-import { Camera, Edit, FilePdf } from "lucide-react";
+import { Camera, Edit, FileText } from "lucide-react";
 
 const showcaseFeatures = [
   {
@@ -39,7 +39,7 @@ const showcaseFeatures = [
     value: "pdf",
     trigger: (
       <>
-        <FilePdf className="mr-2 h-5 w-5" />
+        <FileText className="mr-2 h-5 w-5" />
         Exports PDF Professionnels
       </>
     ),


### PR DESCRIPTION
…lures

The `FilePdf` icon from `lucide-react` was causing build errors because it doesn't exist in the library. This commit replaces it with the `FileText` icon, which has a similar appearance and meaning.

This change ensures the application builds successfully and the UI remains consistent.